### PR TITLE
Optimize the layouts of 標準色

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,16 +66,14 @@
       <div class="card color SITCON-green">
         <ul>
           <li>SITCON 綠</li>
-          <li>PANTONE P 151-14 C</li>
-          <li>CMYK 54 0 76 11</li>
           <li>#77B55A</li>
+          <li>CMYK <span class="nb">54 0 76 11</span></li>
+          <li>PANTONE <span class="nb">P 151-14 C</span></li>
         </ul>
       </div>
       <div class="card color white">
         <ul>
           <li>白色</li>
-          <li></li>
-          <li></li>
           <li>#FFFFFF</li>
         </ul>
       </div>

--- a/style.css
+++ b/style.css
@@ -32,13 +32,15 @@ main {
 
 .color ul {
   margin: 0;
-  padding: 16px;
+  padding: 8px;
   list-style-type: none;
 }
 .color li {
   margin: 0;
-  padding: 0;
-  height: 2em;
+  padding: 8px;
+}
+.color .nb {
+  white-space: nowrap;
 }
 
 .light {


### PR DESCRIPTION
The previous version viewed from mobile looks terrible.

Before (left) / After (right)
![image](https://user-images.githubusercontent.com/13136823/30221902-951132de-94f7-11e7-9f98-327b57770331.png)

Preview: [SITCON branding](https://codepen.io/YuRen/full/vZVBvw/) -- by Yu-Ren Pan ([@YuRen](https://codepen.io/YuRen)) on [CodePen](https://codepen.io)