### PR TITLE
Align the brand in the title vertically

### DIFF
--- a/assets/components.css
+++ b/assets/components.css
@@ -35,6 +35,8 @@ header .header-logo {
 header .header-logo .left > img {
     /* 將 logo 縮小到合理大小 */
     width: 8rem;
+
+    vertical-align: middle;
 }
 
 header .header-logo .right::before {


### PR DESCRIPTION
原本 Logo 上飄：

![CleanShot 2025-01-29 at 00 58 04@2x](https://github.com/user-attachments/assets/c4ba03d7-6d61-4105-b77f-0ef09ba0bb87)

現在 Logo 的 baseline 應該可以跟文字一致了：

![CleanShot 2025-01-29 at 01 03 07@2x](https://github.com/user-attachments/assets/379a982b-aa71-4026-b95e-c36063ba1914)

確認過 Safari、Chrome、Firefox 都不會有 Logo 上飄的問題。