### PR TITLE
Rearrange button sequence

### DIFF
--- a/english.html
+++ b/english.html
@@ -88,14 +88,6 @@
               <!-- Download Grid Block -->
               <div class="download-grid">
                 <a
-                  href="assets/logos/SITCON-Logo.ai"
-                  download
-                  class="download-grid__item"
-                >
-                  <i class="download-grid__icon" aria-hidden="true"></i>
-                  <span class="download-grid__text">Illustrator file</span>
-                </a>
-                <a
                   href="assets/logos/withname.svg"
                   download
                   class="download-grid__item"
@@ -110,6 +102,14 @@
                 >
                   <i class="download-grid__icon" aria-hidden="true"></i>
                   <span class="download-grid__text">PNG</span>
+                </a>
+                <a
+                  href="assets/logos/SITCON-Logo.ai"
+                  download
+                  class="download-grid__item"
+                >
+                  <i class="download-grid__icon" aria-hidden="true"></i>
+                  <span class="download-grid__text">Illustrator file</span>
                 </a>
                 <a
                   href="assets/logos/withname-white.svg"

--- a/english.html
+++ b/english.html
@@ -80,9 +80,9 @@
                 deforming, recoloring, or applying any special effects.
               </p>
               <p class="content-section__description">
-                Please use the <strong>standard green logo</strong> on white or
-                light-colored background, and the <strong>white logo</strong>
-                on dark backgrounds.
+                Please use the <strong>standard green logo</strong> on light
+                backgrounds, and the <strong>white logo</strong> on dark
+                backgrounds.
               </p>
 
               <!-- Download Grid Block -->
@@ -133,7 +133,7 @@
                   class="download-grid__item"
                 >
                   <i class="download-grid__icon" aria-hidden="true"></i>
-                  <span class="download-grid__text">Icon SVG</span>
+                  <span class="download-grid__text">Icon-only SVG</span>
                 </a>
               </div>
             </div>

--- a/english.html
+++ b/english.html
@@ -185,7 +185,7 @@
                       aria-hidden="true"
                     ></i>
                     <span class="examples__title examples__title--correct"
-                      >Correct Examples</span
+                      >Correct</span
                     >
                   </div>
                   <div class="examples__content">
@@ -207,14 +207,12 @@
                       aria-hidden="true"
                     ></i>
                     <span class="examples__title examples__title--incorrect"
-                      >Incorrect Examples</span
+                      >Incorrect</span
                     >
                   </div>
                   <div class="examples__content">
                     <p class="examples__item">Sitcon</p>
-                    <p class="examples__item">
-                      Students' Information Technology Conference (SITCON)
-                    </p>
+                    <p class="examples__item">SitCon</p>
                   </div>
                 </div>
               </div>

--- a/english.html
+++ b/english.html
@@ -93,7 +93,7 @@
                   class="download-grid__item"
                 >
                   <i class="download-grid__icon" aria-hidden="true"></i>
-                  <span class="download-grid__text">SVG</span>
+                  <span class="download-grid__text">Green SVG</span>
                 </a>
                 <a
                   href="assets/logos/withname.png"
@@ -101,7 +101,7 @@
                   class="download-grid__item"
                 >
                   <i class="download-grid__icon" aria-hidden="true"></i>
-                  <span class="download-grid__text">PNG</span>
+                  <span class="download-grid__text">Green PNG</span>
                 </a>
                 <a
                   href="assets/logos/SITCON-Logo.ai"

--- a/index.html
+++ b/index.html
@@ -83,14 +83,6 @@
               <!-- Download Grid Block -->
               <div class="download-grid">
                 <a
-                  href="assets/logos/SITCON-Logo.ai"
-                  download
-                  class="download-grid__item"
-                >
-                  <i class="download-grid__icon" aria-hidden="true"></i>
-                  <span class="download-grid__text">AI 原始檔</span>
-                </a>
-                <a
                   href="assets/logos/withname.svg"
                   download
                   class="download-grid__item"
@@ -105,6 +97,14 @@
                 >
                   <i class="download-grid__icon" aria-hidden="true"></i>
                   <span class="download-grid__text">PNG</span>
+                </a>
+                <a
+                  href="assets/logos/SITCON-Logo.ai"
+                  download
+                  class="download-grid__item"
+                >
+                  <i class="download-grid__icon" aria-hidden="true"></i>
+                  <span class="download-grid__text">AI 原始檔</span>
                 </a>
                 <a
                   href="assets/logos/withname-white.svg"

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                   class="download-grid__item"
                 >
                   <i class="download-grid__icon" aria-hidden="true"></i>
-                  <span class="download-grid__text">SVG</span>
+                  <span class="download-grid__text">綠色 SVG</span>
                 </a>
                 <a
                   href="assets/logos/withname.png"
@@ -96,7 +96,7 @@
                   class="download-grid__item"
                 >
                   <i class="download-grid__icon" aria-hidden="true"></i>
-                  <span class="download-grid__text">PNG</span>
+                  <span class="download-grid__text">綠色 PNG</span>
                 </a>
                 <a
                   href="assets/logos/SITCON-Logo.ai"

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                 本身進行變形、重製、換色、或套用任何特殊效果。
               </p>
               <p class="content-section__description">
-                在白色或淺色背景時請使用<em>綠色標準 Logo</em>，深色背景時則請使用白色。
+                在淺色背景時請使用<em>綠色標準 Logo</em>，深色背景時則請使用白色版本。
               </p>
 
               <!-- Download Grid Block -->


### PR DESCRIPTION
- 更改按鈕順序，讓視覺上能對齊
- 原先「PNG」「白色 PNG」改為「綠色 PNG」「白色 PNG」
    - 在考慮要叫「標準 PNG」還是「綠色 PNG」，但對應到英文的話用顏色感覺比較單純
- 刪除英文錯誤範例「Students' Information Technology Conference (SITCON)」
    - 原本是中文錯誤範例「學生計算機年會（SITCON）」的翻譯

Preview: https://sea-n.github.io/sitcon-branding/
Original: https://sitcon.org/branding/

CC @pan93412 @rschiang @denny0223 